### PR TITLE
Handle depth correctly

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -114,19 +114,22 @@ function processBlocks(blocks) {
     // This block is deeper
     if (lastBlock && block.getDepth() > lastBlock.getDepth()) {
       // Extract reference object from flat context
-      parents.push(lastProcessed); // (mutating)
+      // parents.push(lastProcessed) // (mutating)
       currentContext = lastProcessed[_dataSchema2.default.block.children];
-    } else if (lastBlock && block.getDepth() < lastBlock.getDepth() && parents.length > 0) {
-      // This block is shallower, traverse up the set of parents
-      var parent = parents.pop(); // (mutating)
+    } else if (lastBlock && block.getDepth() < lastBlock.getDepth() && block.getDepth() > 0) {
+      // This block is shallower (but not at the root). We want to find the last
+      // block that is one level shallower than this one to append it to
+      var parent = parents[block.getDepth() - 1];
       currentContext = parent[_dataSchema2.default.block.children];
-    }
-    // If there is no parent, we’re back at the top level
-    if (!currentContext) {
+    } else if (block.getDepth() === 0) {
+      // Reset the parent context if we reach the top level
+      parents = [];
       currentContext = context;
     }
     currentContext.push(output);
     lastProcessed = output[1];
+    // Store a reference to the last block at any given depth
+    parents[block.getDepth()] = lastProcessed;
     lastBlock = block;
   }
 

--- a/src/processor.js
+++ b/src/processor.js
@@ -118,6 +118,8 @@ function processBlocks (blocks, options = {}) {
       let parent = parents[block.getDepth() - 1]
       currentContext = parent[dataSchema.block.children]
     } else if (block.getDepth() === 0) {
+      // Reset the parent context if we reach the top level
+      parents = []
       currentContext = context
     }
     currentContext.push(output)

--- a/src/processor.js
+++ b/src/processor.js
@@ -110,19 +110,20 @@ function processBlocks (blocks, options = {}) {
     // This block is deeper
     if (lastBlock && block.getDepth() > lastBlock.getDepth()) {
       // Extract reference object from flat context
-      parents.push(lastProcessed) // (mutating)
+      // parents.push(lastProcessed) // (mutating)
       currentContext = lastProcessed[dataSchema.block.children]
-    } else if (lastBlock && block.getDepth() < lastBlock.getDepth() && parents.length > 0) {
-      // This block is shallower, traverse up the set of parents
-      let parent = parents.pop() // (mutating)
+    } else if (lastBlock && block.getDepth() < lastBlock.getDepth() && block.getDepth() > 0) {
+      // This block is shallower (but not at the root). We want to find the last
+      // block that is one level shallower than this one to append it to
+      let parent = parents[block.getDepth() - 1]
       currentContext = parent[dataSchema.block.children]
-    }
-    // If there is no parent, we’re back at the top level
-    if (!currentContext) {
+    } else if (block.getDepth() === 0) {
       currentContext = context
     }
     currentContext.push(output)
     lastProcessed = output[1]
+    // Store a reference to the last block at any given depth
+    parents[block.getDepth()] = lastProcessed
     lastBlock = block
   }
 

--- a/test/fixtures/depth-exported.js
+++ b/test/fixtures/depth-exported.js
@@ -1,0 +1,82 @@
+export default [
+  [
+    "block",
+    [
+      "unordered-list-item",
+      "419f3",
+      [
+        [
+          "inline",
+          [
+            [],
+            "level 0"
+          ]
+        ],
+        [
+          "block",
+          [
+            "unordered-list-item",
+            "9121g",
+            [
+              [
+                "inline",
+                [
+                  [],
+                  "level 1"
+                ]
+              ]
+            ]
+          ]
+        ],
+        [
+          "block",
+          [
+            "unordered-list-item",
+            "912ag",
+            [
+              [
+                "inline",
+                [
+                  [],
+                  "level 1"
+                ]
+              ],
+              [
+                "block",
+                [
+                  "unordered-list-item",
+                  "913ag",
+                  [
+                    [
+                      "inline",
+                      [
+                        [],
+                        "level 2"
+                      ]
+                    ]
+                  ]
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+  ],
+  [
+    "block",
+    [
+      "unstyled",
+      "8soca",
+      [
+        [
+          "inline",
+          [
+            [],
+            "level 0"
+          ]
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/fixtures/depth.js
+++ b/test/fixtures/depth.js
@@ -1,0 +1,50 @@
+export default {
+  "entityMap": {},
+  "blocks": [
+    {
+      "key": "419f3",
+      "text": "level 0",
+      "type": "unordered-list-item",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    },
+    {
+      "key": "9121g",
+      "text": "level 1",
+      "type": "unordered-list-item",
+      "depth": 1,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    },
+    {
+      "key": "912ag",
+      "text": "level 1",
+      "type": "unordered-list-item",
+      "depth": 1,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    },
+    {
+      "key": "913ag",
+      "text": "level 2",
+      "type": "unordered-list-item",
+      "depth": 2,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    },
+    {
+      "key": "8soca",
+      "text": "level 0",
+      "type": "unstyled",
+      "depth": 0,
+      "inlineStyleRanges": [],
+      "entityRanges": [],
+      "data": {}
+    }
+  ]
+}

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,8 @@ import exporter from '../src'
 import content from './fixtures/content'
 import contentExported from './fixtures/content-exported'
 import contentExportedEntity from './fixtures/content-exported-entity'
+import depth from './fixtures/depth'
+import depthExported from './fixtures/depth-exported'
 
 test('it should export data', (nest) => {
   const contentState = convertFromRaw(content)
@@ -22,6 +24,7 @@ test('it should export data', (nest) => {
   })
 
   nest.test('... with entity modifications', (assert) => {
+
     // Simple modifiers to make URLs protocol-less
     const options = {
       entityModifiers: {
@@ -42,5 +45,13 @@ test('it should export data', (nest) => {
     assert.deepEqual(actual, expected, 'exported entity data is modified')
     assert.end()
   })
+})
 
+test('... handling depth correctly', (assert) => {
+  const contentState = convertFromRaw(depth)
+  const editorState = EditorState.createWithContent(contentState)
+  const actual = exporter(editorState)
+  const expected = depthExported
+  assert.deepEqual(actual, expected, 'exported data is an array')
+  assert.end()
 })


### PR DESCRIPTION
The previous method of determining which parent to append to as blocks get shallower was naive (and also broken). We’re now storing a reference to the parents based on their depth and using that instead.
