### PR TITLE
Add supports for the ContentBlock metadata

### DIFF
--- a/lib/dataSchema.js
+++ b/lib/dataSchema.js
@@ -13,7 +13,8 @@ var schemaMapping = {
   block: {
     type: 0,
     key: 1,
-    children: 2
+    children: 2,
+    data: 3
   },
   inline: {
     styles: 0,

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * @return {Array} An abstract syntax tree representing the draft-js editorState
  */
 function exporter(editorState) {
-  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
   // Retrieve the content
   var content = editorState.getCurrentContent();

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * @return {Array} An abstract syntax tree representing the draft-js editorState
  */
 function exporter(editorState) {
-  var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
   // Retrieve the content
   var content = editorState.getCurrentContent();

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -35,19 +35,17 @@ function processBlockContent(block, options) {
 
   // Map over the block’s entities
   var entities = entityPieces.map(function (_ref) {
-    var _ref2 = _slicedToArray(_ref, 2);
-
-    var entityKey = _ref2[0];
-    var stylePieces = _ref2[1];
+    var _ref2 = _slicedToArray(_ref, 2),
+        entityKey = _ref2[0],
+        stylePieces = _ref2[1];
 
     var entity = entityKey ? _draftJs.Entity.get(entityKey) : null;
 
     // Extract the inline element
     var inline = stylePieces.map(function (_ref3) {
-      var _ref4 = _slicedToArray(_ref3, 2);
-
-      var text = _ref4[0];
-      var style = _ref4[1];
+      var _ref4 = _slicedToArray(_ref3, 2),
+          text = _ref4[0],
+          style = _ref4[1];
 
       return ['inline', [style.toJS().map(function (s) {
         return s;
@@ -85,7 +83,7 @@ function processBlockContent(block, options) {
  * @return {Array} An abstract syntax tree representing a draft-js content state
  */
 function processBlocks(blocks) {
-  var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
   // Track block context
   var context = context || [];
@@ -106,8 +104,9 @@ function processBlocks(blocks) {
   function processBlock(block) {
     var type = block.getType();
     var key = block.getKey();
+    var data = block.getData().toJS();
 
-    var output = ['block', [type, key, processBlockContent(block, options)]];
+    var output = ['block', [type, key, processBlockContent(block, options), data]];
 
     // Push into context (or not) based on depth. This means either the top-level
     // context array, or the `children` of a previous block

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -35,17 +35,19 @@ function processBlockContent(block, options) {
 
   // Map over the block’s entities
   var entities = entityPieces.map(function (_ref) {
-    var _ref2 = _slicedToArray(_ref, 2),
-        entityKey = _ref2[0],
-        stylePieces = _ref2[1];
+    var _ref2 = _slicedToArray(_ref, 2);
+
+    var entityKey = _ref2[0];
+    var stylePieces = _ref2[1];
 
     var entity = entityKey ? _draftJs.Entity.get(entityKey) : null;
 
     // Extract the inline element
     var inline = stylePieces.map(function (_ref3) {
-      var _ref4 = _slicedToArray(_ref3, 2),
-          text = _ref4[0],
-          style = _ref4[1];
+      var _ref4 = _slicedToArray(_ref3, 2);
+
+      var text = _ref4[0];
+      var style = _ref4[1];
 
       return ['inline', [style.toJS().map(function (s) {
         return s;
@@ -83,7 +85,7 @@ function processBlockContent(block, options) {
  * @return {Array} An abstract syntax tree representing a draft-js content state
  */
 function processBlocks(blocks) {
-  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
   // Track block context
   var context = context || [];
@@ -104,7 +106,7 @@ function processBlocks(blocks) {
   function processBlock(block) {
     var type = block.getType();
     var key = block.getKey();
-    var data = block.getData().toJS();
+    var data = block.getData ? block.getData().toJS() : {};
 
     var output = ['block', [type, key, processBlockContent(block, options), data]];
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "draft-js-utils": "^0.1.4"
   },
   "peerDependencies": {
-    "draft-js": ">=0.7.0"
+    "draft-js": ">=0.8.0"
   },
   "devDependencies": {
     "babel-cli": "6.7.5",

--- a/src/dataSchema.js
+++ b/src/dataSchema.js
@@ -9,6 +9,7 @@ const schemaMapping = {
     type: 0,
     key: 1,
     children: 2,
+    data: 3,
   },
   inline: {
     styles: 0,

--- a/src/processor.js
+++ b/src/processor.js
@@ -95,7 +95,7 @@ function processBlocks (blocks, options = {}) {
   function processBlock (block) {
     const type = block.getType()
     const key = block.getKey()
-    const data = block.getData().toJS()
+    const data = (block.getData) ? block.getData().toJS() : {}
 
     const output = [
       'block',

--- a/src/processor.js
+++ b/src/processor.js
@@ -95,6 +95,7 @@ function processBlocks (blocks, options = {}) {
   function processBlock (block) {
     const type = block.getType()
     const key = block.getKey()
+    const data = block.getData().toJS()
 
     const output = [
       'block',
@@ -102,6 +103,7 @@ function processBlocks (blocks, options = {}) {
         type,
         key,
         processBlockContent(block, options),
+        data,
       ],
     ]
 

--- a/test/fixtures/content-exported-entity.js
+++ b/test/fixtures/content-exported-entity.js
@@ -12,7 +12,8 @@ export default [
             "DraftJS AST Exporter"
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -60,7 +61,8 @@ export default [
             ":"
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -76,7 +78,8 @@ export default [
             "From draft-js internals"
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -92,7 +95,8 @@ export default [
             "To an abstract syntax tree"
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -108,7 +112,8 @@ export default [
             "Extensibility."
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -140,7 +145,8 @@ export default [
             ]
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -183,7 +189,8 @@ export default [
             "."
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ]
 ]

--- a/test/fixtures/content-exported.js
+++ b/test/fixtures/content-exported.js
@@ -12,7 +12,8 @@ export default [
             "DraftJS AST Exporter"
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -60,7 +61,8 @@ export default [
             ":"
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -76,7 +78,8 @@ export default [
             "From draft-js internals"
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -92,7 +95,8 @@ export default [
             "To an abstract syntax tree"
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -108,7 +112,8 @@ export default [
             "Extensibility."
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -140,7 +145,8 @@ export default [
             ]
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ],
   [
@@ -183,7 +189,8 @@ export default [
             "."
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ]
 ]

--- a/test/fixtures/depth-exported.js
+++ b/test/fixtures/depth-exported.js
@@ -25,7 +25,8 @@ export default [
                   "level 1"
                 ]
               ]
-            ]
+            ],
+            {}
           ]
         ],
         [
@@ -54,13 +55,16 @@ export default [
                         "level 2"
                       ]
                     ]
-                  ]
+                  ],
+                  {}
                 ]
               ]
-            ]
+            ],
+            {}
           ]
         ]
-      ]
+      ],
+      {"alignment": "right"}
     ]
   ],
   [
@@ -76,7 +80,8 @@ export default [
             "level 0"
           ]
         ]
-      ]
+      ],
+      {}
     ]
   ]
 ]

--- a/test/fixtures/depth.js
+++ b/test/fixtures/depth.js
@@ -8,7 +8,7 @@ export default {
       "depth": 0,
       "inlineStyleRanges": [],
       "entityRanges": [],
-      "data": {}
+      "data": { "alignment": "right" }
     },
     {
       "key": "9121g",

--- a/test/index.js
+++ b/test/index.js
@@ -55,3 +55,12 @@ test('... handling depth correctly', (assert) => {
   assert.deepEqual(actual, expected, 'exported data is an array')
   assert.end()
 })
+
+test('... handling block metadata', (assert) => {
+  const contentState = convertFromRaw(depth)
+  const editorState = EditorState.createWithContent(contentState)
+  const actual = exporter(editorState)[0][1][3]
+  const expected = depthExported[0][1][3]
+  assert.deepEqual(actual, expected, 'exported metadata matches')
+  assert.end()
+})


### PR DESCRIPTION
Allows you to serialize the data field on a block. Based on https://github.com/icelab/draft-js-ast-exporter/pull/5