### PR TITLE
Update entity fetching to match draft-js API changes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,11 +20,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function exporter(editorState) {
   var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
-  // Retrieve the content
-  var content = editorState.getCurrentContent();
-  var blocks = content.getBlocksAsArray();
+  // Retrieve the content state and its blocks
+  var contentState = editorState.getCurrentContent();
+  var blocks = contentState.getBlocksAsArray();
   // Convert to an abstract syntax tree
-  return (0, _processor2.default)(blocks, options);
+  return (0, _processor2.default)(blocks, contentState, options);
 }
 
 exports.default = exporter;

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -6,8 +6,6 @@ Object.defineProperty(exports, "__esModule", {
 
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
-var _draftJs = require('draft-js');
-
 var _draftJsUtils = require('draft-js-utils');
 
 var _dataSchema = require('./dataSchema');
@@ -20,11 +18,13 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * Process the content of a ContentBlock into appropriate abstract syntax tree
  * nodes based on their type
  * @param  {ContentBlock} block
+ * @param  {ContentState} contentState The draft-js ContentState object
+ *     containing this block
  * @param  {Object} options.entityModifier Map of functions for modifying entity
  * data as it’s exported
  * @return {Array} List of block’s child nodes
  */
-function processBlockContent(block, options) {
+function processBlockContent(block, contentState, options) {
   var entityModifiers = options.entityModifiers || {};
   var text = block.getText();
 
@@ -40,7 +40,7 @@ function processBlockContent(block, options) {
     var entityKey = _ref2[0];
     var stylePieces = _ref2[1];
 
-    var entity = entityKey ? _draftJs.Entity.get(entityKey) : null;
+    var entity = entityKey ? contentState.getEntity(entityKey) : null;
 
     // Extract the inline element
     var inline = stylePieces.map(function (_ref3) {
@@ -81,11 +81,13 @@ function processBlockContent(block, options) {
  * Convert the content from a series of draft-js blocks into an abstract
  * syntax tree
  * @param  {Array} blocks
+ * @param  {ContentState} contentState The draft-js ContentState object
+ *     containing the blocks
  * @param  {Object} options
  * @return {Array} An abstract syntax tree representing a draft-js content state
  */
-function processBlocks(blocks) {
-  var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+function processBlocks(blocks, contentState) {
+  var options = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
 
   // Track block context
   var context = context || [];
@@ -108,7 +110,7 @@ function processBlocks(blocks) {
     var key = block.getKey();
     var data = block.getData ? block.getData().toJS() : {};
 
-    var output = ['block', [type, key, processBlockContent(block, options), data]];
+    var output = ['block', [type, key, processBlockContent(block, contentState, options), data]];
 
     // Push into context (or not) based on depth. This means either the top-level
     // context array, or the `children` of a previous block

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   },
   "homepage": "https://github.com/icelab/draft-js-ast-exporter",
   "dependencies": {
-    "draft-js-utils": "^0.1.4"
+    "draft-js-utils": "^0.1.7"
   },
   "peerDependencies": {
-    "draft-js": ">=0.8.0"
+    "draft-js": ">=0.10.0"
   },
   "devDependencies": {
     "babel-cli": "6.7.5",

--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,11 @@ import processBlocks from './processor'
  * @return {Array} An abstract syntax tree representing the draft-js editorState
  */
 function exporter (editorState, options = {}) {
-  // Retrieve the content
-  const content = editorState.getCurrentContent()
-  const blocks = content.getBlocksAsArray()
+  // Retrieve the content state and its blocks
+  const contentState = editorState.getCurrentContent()
+  const blocks = contentState.getBlocksAsArray()
   // Convert to an abstract syntax tree
-  return processBlocks(blocks, options)
+  return processBlocks(blocks, contentState, options)
 }
 
 export default exporter

--- a/src/processor.js
+++ b/src/processor.js
@@ -1,4 +1,3 @@
-import {Entity} from 'draft-js'
 import {getEntityRanges} from 'draft-js-utils'
 import dataSchema from './dataSchema'
 
@@ -6,11 +5,13 @@ import dataSchema from './dataSchema'
  * Process the content of a ContentBlock into appropriate abstract syntax tree
  * nodes based on their type
  * @param  {ContentBlock} block
+ * @param  {ContentState} contentState The draft-js ContentState object
+ *     containing this block
  * @param  {Object} options.entityModifier Map of functions for modifying entity
  * data as it’s exported
  * @return {Array} List of block’s child nodes
  */
-function processBlockContent (block, options) {
+function processBlockContent (block, contentState, options) {
   const entityModifiers = options.entityModifiers || {}
   let text = block.getText()
 
@@ -21,7 +22,7 @@ function processBlockContent (block, options) {
 
   // Map over the block’s entities
   const entities = entityPieces.map(([entityKey, stylePieces]) => {
-    let entity = entityKey ? Entity.get(entityKey) : null
+    let entity = entityKey ? contentState.getEntity(entityKey) : null
 
     // Extract the inline element
     const inline = stylePieces.map(([text, style]) => {
@@ -72,10 +73,12 @@ function processBlockContent (block, options) {
  * Convert the content from a series of draft-js blocks into an abstract
  * syntax tree
  * @param  {Array} blocks
+ * @param  {ContentState} contentState The draft-js ContentState object
+ *     containing the blocks
  * @param  {Object} options
  * @return {Array} An abstract syntax tree representing a draft-js content state
  */
-function processBlocks (blocks, options = {}) {
+function processBlocks (blocks, contentState, options = {}) {
   // Track block context
   let context = context || []
   let currentContext = context
@@ -102,7 +105,7 @@ function processBlocks (blocks, options = {}) {
       [
         type,
         key,
-        processBlockContent(block, options),
+        processBlockContent(block, contentState, options),
         data,
       ],
     ]


### PR DESCRIPTION
[As of v0.10.0 draft-js entities are contained within the contentState object rather than a global registry](https://facebook.github.io/draft-js/docs/v0-10-api-migration.html#getting-an-entity). We now pass the contentState object around so we can fetch its entities as we process blocks.